### PR TITLE
Fix bug in image_shape

### DIFF
--- a/optimize_anchors.py
+++ b/optimize_anchors.py
@@ -149,7 +149,7 @@ if __name__ == "__main__":
                 entry = np.expand_dims(np.array([-width / 2, -height / 2, width / 2, height / 2]), axis=0)
                 entries = np.append(entries, entry, axis=0)
 
-    image_shape = [max_x, max_y]
+    image_shape = [max_y, max_x]
 
     print('Optimising anchors.')
 


### PR DESCRIPTION
Changed `image_shape` from [width, height] to [height, width] since `keras-retinanet` needs it in this format to generate anchors. :)