### PR TITLE
basedir for csv generator path

### DIFF
--- a/optimize_anchors.py
+++ b/optimize_anchors.py
@@ -2,6 +2,7 @@ import warnings
 import csv
 import argparse
 import sys
+import os
 
 import numpy as np
 import scipy.optimize
@@ -133,7 +134,11 @@ if __name__ == "__main__":
                 continue
 
             if args.resize:
-                img = Image.open(row[0])
+                #Concat base path from annotations file follow retinanet
+                base_dir = os.path.split(args.annotations)[0]
+                relative_path = row[0]
+                image_path = os.path.join(base_dir,relative_path)
+                img = Image.open(image_path)
 
                 if hasattr(img, "shape"):
                     image_shape = img.shape


### PR DESCRIPTION
Looking forward to using this tool, i've got alot of small objects.

To align with the format of the csv generator in keras-retinanet

https://github.com/fizyr/keras-retinanet/blob/563e6ce745372679cc1a2ea1e9a17baff4b640b8/keras_retinanet/preprocessing/csv_generator.py#L193

the image path in the csv file is relative to the location of the annotations file. 